### PR TITLE
feat: delete car bookings + Muriel's trip log guest book

### DIFF
--- a/packages/api/spec.yml
+++ b/packages/api/spec.yml
@@ -161,6 +161,25 @@ paths:
           description: ''
         '500':
           description: ''
+    delete:
+      tags:
+      - Car
+      parameters:
+      - name: id
+        schema:
+          type: integer
+          format: int32
+        in: path
+        required: true
+        deprecated: false
+        explode: true
+      responses:
+        '204':
+          description: ''
+        '404':
+          description: ''
+        '500':
+          description: ''
   /car/bookings/{id}/complete:
     post:
       tags:

--- a/packages/api/src/routes/car.rs
+++ b/packages/api/src/routes/car.rs
@@ -103,6 +103,16 @@ enum CompleteBookingResponse {
     InternalServerError,
 }
 
+#[derive(ApiResponse)]
+enum DeleteBookingResponse {
+    #[oai(status = 204)]
+    NoContent,
+    #[oai(status = 404)]
+    NotFound,
+    #[oai(status = 500)]
+    InternalServerError,
+}
+
 fn to_utc_string(dt: NaiveDateTime) -> String {
     dt.and_utc().to_rfc3339()
 }
@@ -317,6 +327,18 @@ impl CarApi {
             Err(err) => {
                 println!("Error completing car booking {}:\n{:?}", id, err);
                 CompleteBookingResponse::InternalServerError
+            }
+        }
+    }
+
+    #[oai(path = "/car/bookings/:id", method = "delete", tag = "ApiTags::Car")]
+    async fn delete_booking(&self, Path(id): Path<i32>) -> DeleteBookingResponse {
+        match car_bookings::Entity::delete_by_id(id).exec(&*self.db).await {
+            Ok(result) if result.rows_affected == 0 => DeleteBookingResponse::NotFound,
+            Ok(_) => DeleteBookingResponse::NoContent,
+            Err(err) => {
+                println!("Error deleting car booking {}:\n{:?}", id, err);
+                DeleteBookingResponse::InternalServerError
             }
         }
     }

--- a/packages/frontend/src/actions/car.ts
+++ b/packages/frontend/src/actions/car.ts
@@ -114,3 +114,16 @@ export async function completeBooking(
 
 	return { ok: false, error: await readError(res) };
 }
+
+export async function deleteBooking(id: number): Promise<MutationResult> {
+	const res = await fetch(`${config.apiBaseUrl}/car/bookings/${id}`, {
+		method: "DELETE",
+	});
+
+	if (res.ok) {
+		revalidatePath("/car");
+		return { ok: true };
+	}
+
+	return { ok: false, error: await readError(res) };
+}

--- a/packages/frontend/src/app/car/BookingDetail.tsx
+++ b/packages/frontend/src/app/car/BookingDetail.tsx
@@ -2,8 +2,10 @@
 
 import dayjs from "dayjs";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 
-import type { CarBooking } from "@/actions/car";
+import { type CarBooking, deleteBooking } from "@/actions/car";
 
 import { CarModal } from "./CarModal";
 import { driverColor, STATUS_META } from "./constants";
@@ -26,9 +28,39 @@ export function BookingDetail({
 	booking: CarBooking | null;
 	setOpen: (val: boolean) => void;
 }) {
+	const router = useRouter();
 	const open = booking !== null;
 	const color = booking ? driverColor(booking.driver_name) : "#fbbf24";
 	const status = booking ? STATUS_META[booking.status] : undefined;
+
+	const [confirming, setConfirming] = useState(false);
+	const [deleting, setDeleting] = useState(false);
+	const [error, setError] = useState<string>();
+
+	useEffect(() => {
+		if (!open) {
+			setConfirming(false);
+			setDeleting(false);
+			setError(undefined);
+		}
+	}, [open]);
+
+	const handleDelete = async () => {
+		if (!booking) {
+			return;
+		}
+		setDeleting(true);
+		setError(undefined);
+		const result = await deleteBooking(booking.id);
+		setDeleting(false);
+
+		if (result.ok) {
+			setOpen(false);
+			router.refresh();
+		} else {
+			setError(result.error);
+		}
+	};
 
 	return (
 		<CarModal
@@ -92,6 +124,47 @@ export function BookingDetail({
 								: "All booked in. Keys are waiting."}
 						</p>
 					)}
+
+					<div className="mt-5 border-t border-neutral-800 pt-4">
+						{error && (
+							<p className="mb-3 rounded-lg border border-ra_red/40 bg-ra_red/10 px-3 py-2 text-sm text-ra_red">
+								{error}
+							</p>
+						)}
+						{confirming ? (
+							<div className="flex flex-col gap-2">
+								<p className="font-mono text-xs text-neutral-400">
+									Delete this booking for good? This can't be undone.
+								</p>
+								<div className="flex gap-2">
+									<button
+										type="button"
+										onClick={handleDelete}
+										disabled={deleting}
+										className="flex-1 rounded-lg bg-ra_red py-2 text-sm font-semibold text-neutral-950 transition-colors hover:bg-ra_red/90 disabled:cursor-not-allowed disabled:opacity-60"
+									>
+										{deleting ? "Deleting…" : "Yes, delete it"}
+									</button>
+									<button
+										type="button"
+										onClick={() => setConfirming(false)}
+										disabled={deleting}
+										className="flex-1 rounded-lg border border-neutral-700 py-2 text-sm font-medium text-neutral-300 transition-colors hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-60"
+									>
+										Keep it
+									</button>
+								</div>
+							</div>
+						) : (
+							<button
+								type="button"
+								onClick={() => setConfirming(true)}
+								className="font-mono text-xs uppercase tracking-wider text-neutral-500 transition-colors hover:text-ra_red"
+							>
+								🗑 Delete booking
+							</button>
+						)}
+					</div>
 				</div>
 			)}
 		</CarModal>

--- a/packages/frontend/src/app/car/CarPageClient.tsx
+++ b/packages/frontend/src/app/car/CarPageClient.tsx
@@ -12,6 +12,7 @@ import { BookingDialog } from "./BookingDialog";
 import { CarCalendar } from "./CarCalendar";
 import { driverColor, STATUS_META } from "./constants";
 import { MonthlyBreakdown } from "./MonthlyBreakdown";
+import { TripLog } from "./TripLog";
 
 const leagueGothic = League_Gothic({ weight: "variable", subsets: ["latin"] });
 
@@ -228,6 +229,10 @@ export function CarPageClient({ bookings }: { bookings: CarBooking[] }) {
 
 			<div className="mt-6">
 				<MonthlyBreakdown bookings={bookings} />
+			</div>
+
+			<div className="mt-6">
+				<TripLog bookings={bookings} />
 			</div>
 
 			<BookingDialog

--- a/packages/frontend/src/app/car/TripLog.tsx
+++ b/packages/frontend/src/app/car/TripLog.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import dayjs from "dayjs";
+import { useMemo } from "react";
+
+import type { CarBooking } from "@/actions/car";
+
+import { driverColor } from "./constants";
+
+export function TripLog({ bookings }: { bookings: CarBooking[] }) {
+	const trips = useMemo(
+		() =>
+			bookings
+				.filter((b) => b.status === "completed")
+				.sort(
+					(a, b) =>
+						dayjs(b.completed_at ?? b.ends_at).valueOf() -
+						dayjs(a.completed_at ?? a.ends_at).valueOf(),
+				),
+		[bookings],
+	);
+
+	const totalMiles = trips.reduce((sum, t) => sum + (t.miles ?? 0), 0);
+
+	return (
+		<div className="rounded-2xl border border-neutral-800 bg-neutral-900/60 p-5 sm:p-6">
+			<div className="flex items-baseline justify-between gap-2">
+				<div>
+					<h2 className="text-2xl font-semibold tracking-tight text-neutral-50">
+						Muriel's guest book 📖
+					</h2>
+					<p className="font-mono text-xs text-neutral-500">
+						Every trip she's ever taken
+					</p>
+				</div>
+				{trips.length > 0 && (
+					<p className="shrink-0 font-mono text-xs text-neutral-400">
+						<span className="font-bold text-amber-400">{trips.length}</span>{" "}
+						{trips.length === 1 ? "trip" : "trips"} ·{" "}
+						<span className="font-bold text-amber-400">{totalMiles}</span> mi
+					</p>
+				)}
+			</div>
+
+			{trips.length === 0 ? (
+				<p className="mt-8 text-center font-mono text-sm text-neutral-500">
+					No trips logged yet. Be the first to take her out.
+				</p>
+			) : (
+				<ol className="mt-6 flex flex-col gap-4">
+					{trips.map((trip) => {
+						const color = driverColor(trip.driver_name);
+						return (
+							<li key={trip.id} className="flex gap-3">
+								<div className="flex flex-col items-center">
+									<span
+										className="mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full"
+										style={{ backgroundColor: color }}
+									/>
+									<span className="mt-1 w-px flex-1 bg-neutral-800" />
+								</div>
+								<div className="flex-1 pb-1">
+									<div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+										<span className="text-sm font-semibold" style={{ color }}>
+											{trip.driver_name}
+										</span>
+										<span className="font-mono text-xs text-neutral-500">
+											{dayjs(trip.ends_at).format("ddd D MMM YYYY")}
+										</span>
+									</div>
+									<div className="mt-1 flex flex-wrap items-center gap-2 font-mono text-xs text-neutral-400">
+										<span className="rounded bg-neutral-800 px-1.5 py-0.5 font-bold text-neutral-100">
+											{trip.miles ?? 0} mi
+										</span>
+										{trip.paid_for_fuel && (
+											<span className="rounded bg-neutral-800 px-1.5 py-0.5">
+												⛽ £{(trip.fuel_cost ?? 0).toFixed(2)}
+											</span>
+										)}
+									</div>
+									{trip.trip_note && (
+										<p className="mt-2 border-l-2 border-neutral-700 pl-3 text-sm italic text-neutral-200">
+											“{trip.trip_note}”
+										</p>
+									)}
+								</div>
+							</li>
+						);
+					})}
+				</ol>
+			)}
+		</div>
+	);
+}

--- a/packages/frontend/src/client/schema.d.ts
+++ b/packages/frontend/src/client/schema.d.ts
@@ -4,538 +4,794 @@
  */
 
 export interface paths {
-	"/reviews": {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		get: {
-			parameters: {
-				query?: never;
-				header?: never;
-				path?: never;
-				cookie?: never;
-			};
-			requestBody?: never;
-			responses: {
-				/** @description Returns when the review is successfully created. */
-				201: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json; charset=utf-8": components["schemas"]["Review"][];
-					};
-				};
-				/** @description Likely an issue with the database connection. */
-				500: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content?: never;
-				};
-			};
-		};
-		put?: never;
-		post: {
-			parameters: {
-				query?: never;
-				header?: never;
-				path?: never;
-				cookie?: never;
-			};
-			requestBody: {
-				content: {
-					"application/json; charset=utf-8": components["schemas"]["InputModel"];
-				};
-			};
-			responses: {
-				/** @description Returns when the review is successfully created. */
-				201: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content?: never;
-				};
-				/** @description The user has sent bad data. */
-				400: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json; charset=utf-8": components["schemas"]["ErrorMessage"];
-					};
-				};
-				/** @description Issue adding the review to the database. */
-				500: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content?: never;
-				};
-			};
-		};
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	"/events": {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		get: {
-			parameters: {
-				query?: never;
-				header?: never;
-				path?: never;
-				cookie?: never;
-			};
-			requestBody?: never;
-			responses: {
-				/** @description Returns a list of the events */
-				200: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json; charset=utf-8": components["schemas"]["EventDto"][];
-					};
-				};
-				/** @description Likely an issue with the database connection. */
-				500: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content?: never;
-				};
-			};
-		};
-		put?: never;
-		post: {
-			parameters: {
-				query?: never;
-				header?: never;
-				path?: never;
-				cookie?: never;
-			};
-			requestBody: {
-				content: {
-					"application/json; charset=utf-8": components["schemas"]["CreateEventInput"];
-				};
-			};
-			responses: {
-				/** @description Returns a list of the events */
-				200: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content?: never;
-				};
-				/** @description Likely an issue with the database connection. */
-				500: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content?: never;
-				};
-			};
-		};
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	"/events/attendee": {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		get?: never;
-		put?: never;
-		post: {
-			parameters: {
-				query?: never;
-				header?: never;
-				path?: never;
-				cookie?: never;
-			};
-			requestBody: {
-				content: {
-					"application/json; charset=utf-8": components["schemas"]["AttendeeInputModel"];
-				};
-			};
-			responses: {
-				/** @description Returns a list of the events */
-				200: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content?: never;
-				};
-				/** @description Likely an issue with the database connection. */
-				500: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content?: never;
-				};
-			};
-		};
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	"/upload/presigned-link/{object}": {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		get: {
-			parameters: {
-				query?: never;
-				header?: never;
-				path: {
-					object: string;
-				};
-				cookie?: never;
-			};
-			requestBody?: never;
-			responses: {
-				/** @description Returns a list of the events */
-				200: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json; charset=utf-8": components["schemas"]["PresignedLinkDto"];
-					};
-				};
-				/** @description Likely an issue with the database connection. */
-				500: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content?: never;
-				};
-			};
-		};
-		put?: never;
-		post?: never;
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	"/upload": {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		get?: never;
-		put?: never;
-		post: {
-			parameters: {
-				query?: never;
-				header?: never;
-				path?: never;
-				cookie?: never;
-			};
-			requestBody: {
-				content: {
-					"multipart/form-data": {
-						/** Format: binary */
-						upload: string;
-					};
-				};
-			};
-			responses: {
-				/** @description Returns a list of the events */
-				200: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json; charset=utf-8": components["schemas"]["UploadImageDto"];
-					};
-				};
-				/** @description Likely an issue with the database connection. */
-				500: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content?: never;
-				};
-			};
-		};
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	"/info": {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		get: {
-			parameters: {
-				query?: never;
-				header?: never;
-				path?: never;
-				cookie?: never;
-			};
-			requestBody?: never;
-			responses: {
-				/** @description Returns the last deployment time */
-				200: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"text/plain; charset=utf-8": string;
-					};
-				};
-			};
-		};
-		put?: never;
-		post?: never;
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	"/notify": {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		get?: never;
-		put?: never;
-		post: {
-			parameters: {
-				query?: never;
-				header?: never;
-				path?: never;
-				cookie?: never;
-			};
-			requestBody: {
-				content: {
-					"application/json; charset=utf-8": components["schemas"]["SendNotificationRequest"];
-				};
-			};
-			responses: {
-				/** @description Returns a list of the events */
-				200: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json; charset=utf-8": components["schemas"]["SuccessMessage"];
-					};
-				};
-				/** @description Likely an issue with the database connection. */
-				500: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content?: never;
-				};
-			};
-		};
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	"/chat": {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		get?: never;
-		put?: never;
-		post: {
-			parameters: {
-				query?: never;
-				header?: never;
-				path?: never;
-				cookie?: never;
-			};
-			requestBody: {
-				content: {
-					"application/json; charset=utf-8": components["schemas"]["ChatInput"];
-				};
-			};
-			responses: {
-				200: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json; charset=utf-8": components["schemas"]["ChatDto"];
-					};
-				};
-			};
-		};
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
-	"/chat/{housemate}": {
-		parameters: {
-			query?: never;
-			header?: never;
-			path?: never;
-			cookie?: never;
-		};
-		get?: never;
-		put?: never;
-		post: {
-			parameters: {
-				query?: never;
-				header?: never;
-				path: {
-					housemate: components["schemas"]["Housemate"];
-				};
-				cookie?: never;
-			};
-			requestBody: {
-				content: {
-					"application/json; charset=utf-8": components["schemas"]["ChatInput"];
-				};
-			};
-			responses: {
-				200: {
-					headers: {
-						[name: string]: unknown;
-					};
-					content: {
-						"application/json; charset=utf-8": components["schemas"]["ChatDto"];
-					};
-				};
-			};
-		};
-		delete?: never;
-		options?: never;
-		head?: never;
-		patch?: never;
-		trace?: never;
-	};
+    "/reviews": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Returns when the review is successfully created. */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json; charset=utf-8": components["schemas"]["Review"][];
+                    };
+                };
+                /** @description Likely an issue with the database connection. */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json; charset=utf-8": components["schemas"]["InputModel"];
+                };
+            };
+            responses: {
+                /** @description Returns when the review is successfully created. */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description The user has sent bad data. */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json; charset=utf-8": components["schemas"]["ErrorMessage"];
+                    };
+                };
+                /** @description Issue adding the review to the database. */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Returns a list of the events */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json; charset=utf-8": components["schemas"]["EventDto"][];
+                    };
+                };
+                /** @description Likely an issue with the database connection. */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json; charset=utf-8": components["schemas"]["CreateEventInput"];
+                };
+            };
+            responses: {
+                /** @description Returns a list of the events */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Likely an issue with the database connection. */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/events/attendee": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json; charset=utf-8": components["schemas"]["AttendeeInputModel"];
+                };
+            };
+            responses: {
+                /** @description Returns a list of the events */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Likely an issue with the database connection. */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/car/bookings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json; charset=utf-8": components["schemas"]["CarBookingDto"][];
+                    };
+                };
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json; charset=utf-8": components["schemas"]["CreateBookingInput"];
+                };
+            };
+            responses: {
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json; charset=utf-8": components["schemas"]["CarBookingDto"];
+                    };
+                };
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json; charset=utf-8": components["schemas"]["CarErrorMessage"];
+                    };
+                };
+                /** @description The booking clashes with an existing one, or the dates are invalid. */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json; charset=utf-8": components["schemas"]["CarErrorMessage"];
+                    };
+                };
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/car/bookings/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json; charset=utf-8": components["schemas"]["CarBookingDto"];
+                    };
+                };
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/car/bookings/{id}/complete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json; charset=utf-8": components["schemas"]["CompleteBookingInput"];
+                };
+            };
+            responses: {
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json; charset=utf-8": components["schemas"]["CarBookingDto"];
+                    };
+                };
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json; charset=utf-8": components["schemas"]["CarErrorMessage"];
+                    };
+                };
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/upload/presigned-link/{object}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    object: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Returns a list of the events */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json; charset=utf-8": components["schemas"]["PresignedLinkDto"];
+                    };
+                };
+                /** @description Likely an issue with the database connection. */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/upload": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "multipart/form-data": {
+                        /** Format: binary */
+                        upload: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Returns a list of the events */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json; charset=utf-8": components["schemas"]["UploadImageDto"];
+                    };
+                };
+                /** @description Likely an issue with the database connection. */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/info": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Returns the last deployment time */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain; charset=utf-8": string;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/notify": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json; charset=utf-8": components["schemas"]["SendNotificationRequest"];
+                };
+            };
+            responses: {
+                /** @description Returns a list of the events */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json; charset=utf-8": components["schemas"]["SuccessMessage"];
+                    };
+                };
+                /** @description Likely an issue with the database connection. */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/chat": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json; charset=utf-8": components["schemas"]["ChatInput"];
+                };
+            };
+            responses: {
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json; charset=utf-8": components["schemas"]["ChatDto"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/chat/{housemate}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    housemate: components["schemas"]["Housemate"];
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json; charset=utf-8": components["schemas"]["ChatInput"];
+                };
+            };
+            responses: {
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json; charset=utf-8": components["schemas"]["ChatDto"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-	schemas: {
-		Attendee: {
-			/** Format: int32 */
-			id: number;
-			/** Format: int32 */
-			event_id: number;
-			name: string;
-			/** Format: naive-date-time */
-			created_at: string;
-		};
-		AttendeeInputModel: {
-			name: string;
-			/** Format: int32 */
-			event_id: number;
-		};
-		ChatDto: {
-			message: string;
-		};
-		ChatInput: {
-			message: string;
-		};
-		CreateEventInput: {
-			name: string;
-			location: string;
-			description: string;
-			starts_at: string;
-			ends_at: string;
-			/** Format: int32 */
-			image_id: number;
-		};
-		ErrorMessage: {
-			message: string;
-		};
-		EventDto: {
-			/** Format: int32 */
-			id: number;
-			name: string;
-			location: string;
-			description: string;
-			starts_at: string;
-			ends_at: string;
-			attendees: components["schemas"]["Attendee"][];
-			upload_key?: string;
-		};
-		/** @enum {string} */
-		Housemate: "Luke" | "Jonny" | "George" | "Fraser";
-		InputModel: {
-			name: string;
-			title: string;
-			description: string;
-			/** Format: int32 */
-			stars: number;
-		};
-		PresignedLinkDto: {
-			presigned_link: string;
-		};
-		Review: {
-			/** Format: int32 */
-			id: number;
-			name: string;
-			title: string;
-			description: string;
-			/** Format: int32 */
-			stars: number;
-			is_archived: boolean;
-			/** Format: naive-date-time */
-			created_at: string;
-		};
-		SendNotificationRequest: {
-			id: string;
-		};
-		SuccessMessage: {
-			message: string;
-		};
-		UploadImageDto: {
-			/** Format: int32 */
-			image_id: number;
-		};
-	};
-	responses: never;
-	parameters: never;
-	requestBodies: never;
-	headers: never;
-	pathItems: never;
+    schemas: {
+        Attendee: {
+            /** Format: int32 */
+            id: number;
+            /** Format: int32 */
+            event_id: number;
+            name: string;
+            /** Format: naive-date-time */
+            created_at: string;
+        };
+        AttendeeInputModel: {
+            name: string;
+            /** Format: int32 */
+            event_id: number;
+        };
+        CarBookingDto: {
+            /** Format: int32 */
+            id: number;
+            driver_name: string;
+            starts_at: string;
+            ends_at: string;
+            /** Format: int32 */
+            miles?: number;
+            paid_for_fuel: boolean;
+            /** Format: double */
+            fuel_cost?: number;
+            trip_note?: string;
+            completed_at?: string;
+            created_at: string;
+            /** @description One of: upcoming, active, awaiting_completion, completed */
+            status: string;
+        };
+        CarErrorMessage: {
+            message: string;
+        };
+        ChatDto: {
+            message: string;
+        };
+        ChatInput: {
+            message: string;
+        };
+        CompleteBookingInput: {
+            /** Format: int32 */
+            miles: number;
+            paid_for_fuel: boolean;
+            /** Format: double */
+            fuel_cost?: number;
+            trip_note?: string;
+        };
+        CreateBookingInput: {
+            driver_name: string;
+            starts_at: string;
+            ends_at: string;
+        };
+        CreateEventInput: {
+            name: string;
+            location: string;
+            description: string;
+            starts_at: string;
+            ends_at: string;
+            /** Format: int32 */
+            image_id: number;
+        };
+        ErrorMessage: {
+            message: string;
+        };
+        EventDto: {
+            /** Format: int32 */
+            id: number;
+            name: string;
+            location: string;
+            description: string;
+            starts_at: string;
+            ends_at: string;
+            attendees: components["schemas"]["Attendee"][];
+            upload_key?: string;
+        };
+        /** @enum {string} */
+        Housemate: "Luke" | "Jonny" | "George" | "Fraser";
+        InputModel: {
+            name: string;
+            title: string;
+            description: string;
+            /** Format: int32 */
+            stars: number;
+        };
+        PresignedLinkDto: {
+            presigned_link: string;
+        };
+        Review: {
+            /** Format: int32 */
+            id: number;
+            name: string;
+            title: string;
+            description: string;
+            /** Format: int32 */
+            stars: number;
+            is_archived: boolean;
+            /** Format: naive-date-time */
+            created_at: string;
+        };
+        SendNotificationRequest: {
+            id: string;
+        };
+        SuccessMessage: {
+            message: string;
+        };
+        UploadImageDto: {
+            /** Format: int32 */
+            image_id: number;
+        };
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export type operations = Record<string, never>;


### PR DESCRIPTION
Adds a `DELETE /car/bookings/:id` endpoint and a `deleteBooking` server action, surfaced as a two-step confirm "Delete booking" control in the booking detail modal so a mis-made booking can be removed. Adds "Muriel's guest book" at the bottom of the car page — a chronological feed of every completed trip showing the driver, date, miles, fuel and trip note. The generated OpenAPI types (`schema.d.ts`) are refreshed from the updated `spec.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)